### PR TITLE
feat:  use semantic versioning

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,7 @@
+{
+    "plugins": [
+        '@semantic-release/commit-analyzer', 
+        '@semantic-release/release-notes-generator', 
+        '@semantic-release/github'
+    ]
+}

--- a/.releaserc
+++ b/.releaserc
@@ -3,6 +3,5 @@
         '@semantic-release/commit-analyzer', 
         '@semantic-release/release-notes-generator', 
         '@semantic-release/github'
-    ],
-    "branch": "version"
+    ]
 }

--- a/.releaserc
+++ b/.releaserc
@@ -3,6 +3,6 @@
         '@semantic-release/commit-analyzer', 
         '@semantic-release/release-notes-generator', 
         '@semantic-release/github'
-    ]
+    ],
     "branch": "version"
 }

--- a/.releaserc
+++ b/.releaserc
@@ -4,4 +4,5 @@
         '@semantic-release/release-notes-generator', 
         '@semantic-release/github'
     ]
+    "branch": "version"
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,11 @@ version: 1.1.{build}
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
-  version: '{version}'
-  package_version: '{version}'
-  assembly_version: '{version}'
-  file_version: '{version}'
-  informational_version: '{version}'
+  version: '{$Version}'
+  package_version: '{$Version}'
+  assembly_version: '{$Version}'
+  file_version: '{$Version}'
+  informational_version: '{$Version}'
 
 install:
   - npm install -g semantic-release@15
@@ -20,11 +20,15 @@ install:
         }
       }
 
-      echo "Version is $Version"
-      
-      Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"
-      Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"
-      Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
+      if ($Version -eq $null)
+      {
+        $Version = $version
+      }
+      echo "Version is $Version version is $version"
+
+      Set-AppveyorBuildVariable -Name "assembly_version" -Value "$Version"
+      Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "$Version"
+      Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "$Version"
 
 build_script:
   - cmd: dotnet publish -f netcoreapp2.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 version: 1.1.{build}
 
 init: 
-  - ps: >-
-    Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0"  
-    Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0.0"  
-    Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
+- ps: >-
+  Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"  
+  Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"  
+  Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
 
 dotnet_csproj:
   patch: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,11 @@ version: 1.1.{build}
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
-  version: '${Version}'
-  package_version: '${Version}'
-  assembly_version: '${Version}'
-  file_version: '${Version}'
-  informational_version: '${Version}'
+  version: '${app_version}'
+  package_version: '${app_version}'
+  assembly_version: '${app_version}'
+  file_version: '${app_version}'
+  informational_version: '${app_version}'
 
 cache:
   - '%APPDATA%\npm-cache'
@@ -29,9 +29,7 @@ install:
       }
       echo "Version is $Version version is $version build is $build"
 
-      Set-AppveyorBuildVariable -Name "assembly_version" -Value "$Version"
-      Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "$Version"
-      Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "$Version"
+      Set-Variable -Name app_version -Value "$Version" -Scope global
 
 build_script:
   - cmd: dotnet publish -f netcoreapp2.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 version: 1.1.{build}
 
-init: 
-- ps: >-
-  Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"  
-  Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"  
-  Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
+init:
+  - ps: |
+    Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"  
+    Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"  
+    Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
 
 dotnet_csproj:
   patch: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,15 +4,15 @@ version: 1.1.{build}
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
-  version: '{$Version}'
-  package_version: '{$Version}'
-  assembly_version: '{$Version}'
-  file_version: '{$Version}'
-  informational_version: '{$Version}'
+  version: '{$assembly_version}'
+  package_version: '{$assembly_version}'
+  assembly_version: '{$assembly_version}'
+  file_version: '{$assembly_version}'
+  informational_version: '{$assembly_version}'
 
 cache:
   - '%APPDATA%\npm-cache'
-  
+
 install:
   - npm install -g semantic-release@15
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,5 @@
 version: 1.1.{build}
 
-init:
-  - ps: |
-    Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"  
-    Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"  
-    Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
 
 dotnet_csproj:
   patch: true
@@ -17,6 +12,10 @@ dotnet_csproj:
 
 install:
   - npm install -g semantic-release@15
+  - ps: |
+    Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"  
+    Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"  
+    Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
 
 build_script:
   - cmd: dotnet publish -f netcoreapp2.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,15 @@ dotnet_csproj:
 install:
   - npm install -g semantic-release@15
   - ps: |
-      semantic-release --dry-run | Select-String -Pattern '^# '
+      semantic-release --dry-run |  %{ 
+        $fields = -split $_;
+        if ($fields[0] -eq "#") {
+          Set-Variable -Name "Version" -Value $fields[1]
+        }
+      }
+
+      echo "Version is $Version"
+      
       Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"
       Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"
       Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,11 @@ version: 1.1.{build}
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
-  version: '{$assembly_version}'
-  package_version: '{$assembly_version}'
-  assembly_version: '{$assembly_version}'
-  file_version: '{$assembly_version}'
-  informational_version: '{$assembly_version}'
+  version: '{assembly_version}'
+  package_version: '{assembly_version}'
+  assembly_version: '{assembly_version}'
+  file_version: '{assembly_version}'
+  informational_version: '{assembly_version}'
 
 cache:
   - '%APPDATA%\npm-cache'
@@ -23,10 +23,6 @@ install:
         }
       }
 
-      if ($Version -eq $null)
-      {
-        $Version = "0.0.$build"
-      }
       echo "Version is $Version version is $version build is $build"
 
       Set-AppveyorBuildVariable -Name "assembly_version" -Value "$Version"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
       {
         $Version = $version
       }
-      echo "Version is $Version version is $version"
+      echo "Version is $Version version is $version build is $build"
 
       Set-AppveyorBuildVariable -Name "assembly_version" -Value "$Version"
       Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "$Version"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 version: 1.1.{build}
 
-
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
@@ -35,3 +34,6 @@ build_script:
 test_script: 
   - cmd: dotnet test -f netcoreapp2.1
 
+deploy_script:
+  - semantic-release
+  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.1.{build}
 
 init: 
-  - ps: |
+  - ps: >-
     Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0"  
     Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0.0"  
     Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ install:
   - npm install -g semantic-release@15
   - ps: |
       Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"
+      Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"
+      Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
 
 build_script:
   - cmd: dotnet publish -f netcoreapp2.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ dotnet_csproj:
 install:
   - npm install -g semantic-release@15
   - ps: |
+      semantic-release --dry-run | Select-String -Pattern '^# '
       Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"
       Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"
       Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ dotnet_csproj:
   informational_version: $(app_version)
 
 cache:
-  - '%APPDATA%\npm-cache'
+  - '%APPDATA%\npm'
 
 install:
   - npm install -g semantic-release@15
@@ -36,4 +36,5 @@ test_script:
 
 deploy_script:
   - semantic-release
-  
+
+skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,11 @@
 version: 1.1.{build}
+
+init: 
+  - ps: |
+    Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0"  
+    Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0.0"  
+    Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
+
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
@@ -8,8 +15,12 @@ dotnet_csproj:
   file_version: '{version}'
   informational_version: '{version}'
 
+install:
+  - npm install -g semantic-release@15
+
 build_script:
   - cmd: dotnet publish -f netcoreapp2.1
 
 test_script: 
   - cmd: dotnet test -f netcoreapp2.1
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,11 @@ version: 1.1.{build}
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
-  version: '{assembly_version}'
-  package_version: '{assembly_version}'
-  assembly_version: '{assembly_version}'
-  file_version: '{assembly_version}'
-  informational_version: '{assembly_version}'
+  version: '${Version}'
+  package_version: '${Version}'
+  assembly_version: '${Version}'
+  file_version: '${Version}'
+  informational_version: '${Version}'
 
 cache:
   - '%APPDATA%\npm-cache'
@@ -23,6 +23,10 @@ install:
         }
       }
 
+      if ($Version -eq $null)
+      {
+        $Version = "0.0.1"
+      }
       echo "Version is $Version version is $version build is $build"
 
       Set-AppveyorBuildVariable -Name "assembly_version" -Value "$Version"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,11 @@ version: 1.1.{build}
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
-  version: '${app_version}'
-  package_version: '${app_version}'
-  assembly_version: '${app_version}'
-  file_version: '${app_version}'
-  informational_version: '${app_version}'
+  version: $(app_version)
+  package_version: $(app_version)
+  assembly_version: $(app_version}
+  file_version: $(app_version)
+  informational_version: $(app_version)
 
 cache:
   - '%APPDATA%\npm-cache'
@@ -19,17 +19,15 @@ install:
       semantic-release --dry-run |  %{ 
         $fields = -split $_;
         if ($fields[0] -eq "#") {
-          Set-Variable -Name "Version" -Value $fields[1]
+          Set-Variable -Name "app_version" -Value $fields[1]
         }
       }
 
-      if ($Version -eq $null)
+      if ($app_version -eq $null)
       {
-        $Version = "0.0.1"
+        Set-Variable -Name "app_version" -Value 0.0.1
       }
-      echo "Version is $Version version is $version build is $build"
-
-      Set-Variable -Name app_version -Value "$Version" -Scope global
+      echo "Version is $app_version version is $version build is $build"
 
 build_script:
   - cmd: dotnet publish -f netcoreapp2.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,8 @@ dotnet_csproj:
 
 install:
   - npm install -g semantic-release@15
-  - ps: Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"  
+  - ps: |
+      Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"
 
 build_script:
   - cmd: dotnet publish -f netcoreapp2.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ dotnet_csproj:
   file_version: '{$Version}'
   informational_version: '{$Version}'
 
+cache:
+  - '%APPDATA%\npm-cache'
+  
 install:
   - npm install -g semantic-release@15
   - ps: |
@@ -22,7 +25,7 @@ install:
 
       if ($Version -eq $null)
       {
-        $Version = $version
+        $Version = "0.0.$build"
       }
       echo "Version is $Version version is $version build is $build"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,7 @@ dotnet_csproj:
 
 install:
   - npm install -g semantic-release@15
-  - ps: |
-    Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"  
-    #Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"  
-    #Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
+  - ps: Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"  
 
 build_script:
   - cmd: dotnet publish -f netcoreapp2.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ install:
   - npm install -g semantic-release@15
   - ps: |
     Set-AppveyorBuildVariable -Name "assembly_version" -Value "1.0.0"  
-    Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"  
-    Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
+    #Set-AppveyorBuildVariable -Name "assembly_file_version" -Value "1.0.0"  
+    #Set-AppveyorBuildVariable -Name "assembly_informational_version" -Value "1.0.0"
 
 build_script:
   - cmd: dotnet publish -f netcoreapp2.1


### PR DESCRIPTION
This will release the application using semantic versioning.  You just need to add a tag to your commits and that will automatically increase the right version.

Here is an example of the release type that will be done based on a commit messages:

If you want to merge it,  please squash it

| Commit message                                                                                                                                                                                   | Release type               |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
| `fix: stop graphite breaking when too much pressure applied`                                                                                                                             | Patch Release              |
| `feat: add 'graphiteWidth' option`                                                                                                                                                       | ~~Minor~~ Feature Release  |
| `perf: remove graphiteWidth option`<br><br>`BREAKING CHANGE: The graphiteWidth option has been removed.`<br>`The default graphite width of 10mm is always used for performance reasons.` | ~~Major~~ Breaking Release |


There is a one time setup you need to do:
Additional setup instructions are required:

1. Create a personal access token with repo access
2. go to appveyor -> UnityPackager -> settings -> Environment
3. add variable named "GITHUB_TOKEN"
4. paste the access token,
5. click the encrypt icon

